### PR TITLE
Refactoring base operations interface

### DIFF
--- a/app/concepts/ticket/operation/delete.rb
+++ b/app/concepts/ticket/operation/delete.rb
@@ -5,7 +5,7 @@ class Ticket
 
     include Trailblazer::Operation::Responder
 
-    def process(params)
+    def process(_params)
       model.destroy
     end
   end

--- a/app/concepts/ticket/operation/index.rb
+++ b/app/concepts/ticket/operation/index.rb
@@ -17,7 +17,7 @@ class Ticket
       workspace.tickets.limit(limit).offset(offset)
     end
 
-    def process(*)
+    def process(_params)
     end
   end
 end

--- a/app/concepts/ticket/operation/show.rb
+++ b/app/concepts/ticket/operation/show.rb
@@ -9,7 +9,7 @@ class Ticket
 
     representer Ticket::Representer::Show
 
-    def process(*)
+    def process(_params)
     end
   end
 end

--- a/app/concepts/workspace/operation/delete.rb
+++ b/app/concepts/workspace/operation/delete.rb
@@ -9,7 +9,7 @@ class Workspace
       property :id
     end
 
-    def process(params)
+    def process(_params)
       model.destroy
     end
   end

--- a/app/concepts/workspace/operation/index.rb
+++ b/app/concepts/workspace/operation/index.rb
@@ -14,7 +14,7 @@ class Workspace
       Workspace.limit(limit).offset(limit * (page.to_i - 1))
     end
 
-    def process(*)
+    def process(_params)
     end
   end
 end

--- a/app/concepts/workspace/operation/show.rb
+++ b/app/concepts/workspace/operation/show.rb
@@ -9,7 +9,7 @@ class Workspace
 
     representer Representer::Show
 
-    def process(*)
+    def process(_params)
     end
   end
 end


### PR DESCRIPTION
Use `def process(_params)` signature for process method with unused parameters
