### PR TITLE
Fix Session::SignIn validation rule

### DIFF
--- a/app/concepts/session/operation/sign_in.rb
+++ b/app/concepts/session/operation/sign_in.rb
@@ -23,7 +23,7 @@ class Session
         required(:email).filled(:str?)
         required(:password).filled(:str?)
 
-        rule(user_exists: [:email, :password]) do |email, password|
+        rule(password: [:email, :password]) do |email, password|
           password.password_ok?(email)
         end
       end


### PR DESCRIPTION
This fix need for upgrade dry-validation gem to next version, which contains
breaking changes.